### PR TITLE
Function to add widget area to category header area

### DIFF
--- a/wp-content/themes/midwestcenter/functions.php
+++ b/wp-content/themes/midwestcenter/functions.php
@@ -165,3 +165,23 @@ function largo_child_require_files() {
 	}
 }
 add_action( 'after_setup_theme', 'largo_child_require_files' );
+
+/**
+ * Adds the ability to include a widget area in the header of a category archive page.
+ * The widget area must use the same name as the slug of the category it is going to be used on.
+ * 
+ * If a widget area with a matching name does not exist or is empty, no widget area will be displayed.
+ * 
+ * @see https://github.com/INN/umbrella-mwcir/issues/42
+ */
+function category_header_widget_area() {
+
+	$category = get_queried_object();
+	$category_slug = $category->slug;
+
+	if ( is_active_sidebar( $category_slug ) ) {
+		dynamic_sidebar( $category_slug );
+	}
+
+}
+add_action( 'largo_category_after_description_in_header', 'category_header_widget_area' );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a widget area to the top of category pages if there is an [active](https://developer.wordpress.org/reference/functions/is_active_sidebar/) with a name that matches the current cateogy's slug using `largo_category_after_description_in_header` action

<img width="1336" alt="Screen Shot 2020-04-29 at 1 30 31 PM" src="https://user-images.githubusercontent.com/18353636/80634418-78e7bf00-8a28-11ea-8bd6-47fab9c1d2ef.png">

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #42

## Testing/Questions

Features that this PR affects:

- Category pages

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Do we need to add any styling here?
- [ ] Any other considerations we need to make?

Steps to test this PR:

1. Choose a category, find its slug, and add a custom sidebar named after the category slug
2. Make sure the sidebar doesn't appear on the category page if its empty
3. Make sure a sidebar doesn't appear on the category page if one doesn't exist with a matching name
4. Make sure the sidebar does appear on the category page if it has widgets inside of it